### PR TITLE
@定数を使用してcore_component.ex内のrows={@rows}にしたい

### DIFF
--- a/lib/contact_web/components/core_components.ex
+++ b/lib/contact_web/components/core_components.ex
@@ -1,4 +1,7 @@
 defmodule ContactWeb.CoreComponents do
+#定数を定義
+  @rows 2
+
   @moduledoc """
   Provides core UI components.
 
@@ -280,6 +283,8 @@ defmodule ContactWeb.CoreComponents do
     |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
     |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
     |> assign_new(:value, fn -> field.value end)
+    |> assign(:rows, @rows) #この時点では期待値通りassignsに:rowsのキーバリューが入っている
+    |> IO.inspect()
     |> input()
   end
 
@@ -327,6 +332,10 @@ defmodule ContactWeb.CoreComponents do
   end
 
   def input(%{type: "textarea"} = assigns) do
+    # 詰まっている箇所
+    # ■期待値 assignsの中に:rowsのキーバリューが渡って来てほしい。
+    # ■現在の状態 渡って来てない。理由が分からない（6月16日時点）
+    #   └よって、rows={@rows}に変えると:rowsというキーが見つからないと怒られる。
     ~H"""
     <div phx-feedback-for={@name}>
       <.label for={@id}><%= @label %></.label>

--- a/lib/contact_web/components/core_components.ex
+++ b/lib/contact_web/components/core_components.ex
@@ -284,7 +284,7 @@ defmodule ContactWeb.CoreComponents do
     |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
     |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
     |> assign_new(:value, fn -> field.value end)
-    |> assign(:rows, @rows) #この時点では期待値通りassignsに:rowsのキーバリューが入っている
+    |> assign(:rows, @rows)
     |> input()
   end
 
@@ -332,10 +332,6 @@ defmodule ContactWeb.CoreComponents do
   end
 
   def input(%{type: "textarea"} = assigns) do
-    # 詰まっている箇所
-    # ■期待値 assignsの中に:rowsのキーバリューが渡って来てほしい。
-    # ■現在の状態 渡って来てない。理由が分からない（6月16日時点）
-    #   └よって、rows={@rows}に変えると:rowsというキーが見つからないと怒られる。
     ~H"""
     <div phx-feedback-for={@name}>
       <.label for={@id}><%= @label %></.label>

--- a/lib/contact_web/components/core_components.ex
+++ b/lib/contact_web/components/core_components.ex
@@ -256,6 +256,7 @@ defmodule ContactWeb.CoreComponents do
   attr :name, :any
   attr :label, :string, default: nil
   attr :value, :any
+  attr :rows, :integer, default: nil
 
   attr :type, :string,
     default: "text",
@@ -341,7 +342,7 @@ defmodule ContactWeb.CoreComponents do
       <textarea
         id={@id}
         name={@name}
-        rows="5"
+        rows={@rows}
         class={[
           "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
           "phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400",

--- a/lib/contact_web/components/core_components.ex
+++ b/lib/contact_web/components/core_components.ex
@@ -284,7 +284,6 @@ defmodule ContactWeb.CoreComponents do
     |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
     |> assign_new(:value, fn -> field.value end)
     |> assign(:rows, @rows) #この時点では期待値通りassignsに:rowsのキーバリューが入っている
-    |> IO.inspect()
     |> input()
   end
 


### PR DESCRIPTION
■目的
core_component.ex内の344行目を
rows="5" から rows={@rows}にしたい。

■仮説
defmoduleの直下に@rowsを定義し、input関数内にassignすればいいのでは？

■やったこと
1. 3行目 defmoduleの直下に@rowsを定義
2. 286行目assign(:rows, @rows)でassignsの中にキーバリューのペアを持たせる

■結果
rows="5" から rows={@rows}にした場合、キーが見つからないと怒られた。

```
[error] GenServer #PID<0.637.0> terminating
** (KeyError) key :rows not found in: %{__changed__: nil, __given__: %{__changed__: nil, __given__: %{__changed__: nil, field: %Phoenix.HTML.FormField{id: "comment_message", name: "comment[message]", errors: [], field: :message, form: %Phoenix.HTML.Form{source: #Ecto.Changeset<action: nil, changes: %{}, errors: [name: {"can't be blank", [validation: :required]}, message: {"can't be blank", [validation: :required]}], data: #Contact.Comments.Comment<>, valid?: false>, impl: Phoenix.HTML.FormData.Ecto.Changeset, id: "comment", name: "comment", data: %Contact.Comments.Comment{__meta__: #Ecto.Schema.Metadata<:built, "comments">, id: nil, message: nil, name: nil, inserted_at: nil, updated_at: nil}, hidden: [], params: %{}, errors: [], options: [method: "post"], index: nil, action: nil}, value: nil}, label: "Message", type: "textarea"}, errors: [], field: nil, id: "comment_message", inner_block: [], label: "Message", multiple: false, name: "comment[message]", prompt: nil, rest: %{}, type: "textarea", value: nil}, errors: [], field: nil, id: "comment_message", inner_block: [], label: "Message", multiple: false, name: "comment[message]", prompt: nil, rest: %{}, type: "textarea", value: nil}
```