### PR TITLE
@rows 2 で定義したモジュール定数をattr/3のデフォルト値に変更

### DIFF
--- a/lib/contact_web/components/core_components.ex
+++ b/lib/contact_web/components/core_components.ex
@@ -1,7 +1,4 @@
 defmodule ContactWeb.CoreComponents do
-#定数を定義
-  @rows 2
-
   @moduledoc """
   Provides core UI components.
 
@@ -256,7 +253,7 @@ defmodule ContactWeb.CoreComponents do
   attr :name, :any
   attr :label, :string, default: nil
   attr :value, :any
-  attr :rows, :integer, default: nil
+  attr :rows, :integer, default: 2
 
   attr :type, :string,
     default: "text",
@@ -284,7 +281,6 @@ defmodule ContactWeb.CoreComponents do
     |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
     |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
     |> assign_new(:value, fn -> field.value end)
-    |> assign(:rows, @rows)
     |> input()
   end
 


### PR DESCRIPTION
- モジュールの定数ではなくて、attrにdefault値を設定できるのでそちらのほうが関連する値がすぐわかるため
※今回は@定数の練習だったのでそのままにしたが、本来は1箇所でしか使わない値は定数にすべきではない。

- attr/3で定義したものはassignsに入っているので、改めてassign/3をする必要は無いため削除。


