### PR TITLE
core_components.exの外に独自の関数コンポーネントを作る

### DIFF
--- a/lib/contact_web/components/core_components.ex
+++ b/lib/contact_web/components/core_components.ex
@@ -328,6 +328,7 @@ defmodule ContactWeb.CoreComponents do
   end
 
   def input(%{type: "textarea"} = assigns) do
+    IO.inspect("Messageのビュー")
     ~H"""
     <div phx-feedback-for={@name}>
       <.label for={@id}><%= @label %></.label>
@@ -350,6 +351,7 @@ defmodule ContactWeb.CoreComponents do
 
   # All other inputs text, datetime-local, url, password, etc. are handled here...
   def input(assigns) do
+    IO.inspect("Nameのビュー")
     ~H"""
     <div phx-feedback-for={@name}>
       <.label for={@id}><%= @label %></.label>

--- a/lib/contact_web/components/my_components.ex
+++ b/lib/contact_web/components/my_components.ex
@@ -1,9 +1,5 @@
 defmodule ContactWeb.Mycomponents do
   use Phoenix.Component
-
-  alias Phoenix.LiveView.JS
-  import ContactWeb.Gettext
-
   import ContactWeb.CoreComponents
 
   @doc """
@@ -32,7 +28,7 @@ defmodule ContactWeb.Mycomponents do
       <.input name="my-input" errors={["oh no!"]} />
   """
   attr :id, :any, default: nil
-  attr :name, :any, default: "pochi"
+  attr :name, :any
   attr :label, :string, default: nil
   attr :value, :any
   attr :rows, :integer, default: 2
@@ -57,11 +53,12 @@ defmodule ContactWeb.Mycomponents do
 
   slot :inner_block
 
-  def input(%{type: "fuga"} = assigns) do
-    IO.inspect("fugaのビュー")
-    IO.inspect(assigns)
+
+  #assignsの中身を必要としないコンポーネント（こちらは動く）
+  def input(%{type: "hoge"} = assigns) do
+    IO.inspect("独自のコンポーネント1")
     ~H"""
-    <p>Hello, <%= @name %>!</p>
+    <p>Thank you for your feedback!</p>
     """
   end
 

--- a/lib/contact_web/components/my_components.ex
+++ b/lib/contact_web/components/my_components.ex
@@ -1,6 +1,7 @@
 defmodule ContactWeb.Mycomponents do
   use Phoenix.Component
-  import ContactWeb.CoreComponents
+  alias ContactWeb.CoreComponents
+  alias ContactWeb.Mycomponents
 
   @doc """
   Renders an input with label and error messages.
@@ -53,6 +54,14 @@ defmodule ContactWeb.Mycomponents do
 
   slot :inner_block
 
+  def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
+    assigns
+    |> assign(field: nil, id: assigns.id || field.id)
+    |> assign(:errors, Enum.map(field.errors, &CoreComponents.translate_error(&1)))
+    |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
+    |> assign_new(:value, fn -> field.value end)
+    |> Mycomponents.input()
+  end
 
   #assignsの中身を必要としないコンポーネント（こちらは動く）
   def input(%{type: "hoge"} = assigns) do
@@ -67,20 +76,20 @@ defmodule ContactWeb.Mycomponents do
     IO.inspect("独自のコンポーネント2")
     ~H"""
     <div phx-feedback-for={@name}>
-      <.label for={@id}><%= @label %></.label>
+      <CoreComponents.label for={@id}><%= @label %></CoreComponents.label>
       <textarea
         id={@id}
         name={@name}
         rows={@rows}
         class={[
           "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
-          "phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400",
+          "phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400 bg-green-500/50",
           @errors == [] && "border-zinc-300 focus:border-zinc-400",
           @errors != [] && "border-rose-400 focus:border-rose-400"
         ]}
         {@rest}
       ><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
-      <.error :for={msg <- @errors}><%= msg %></.error>
+      <CoreComponents.error :for={msg <- @errors}><%= msg %></CoreComponents.error>
     </div>
     """
   end

--- a/lib/contact_web/components/my_components.ex
+++ b/lib/contact_web/components/my_components.ex
@@ -62,4 +62,28 @@ defmodule ContactWeb.Mycomponents do
     """
   end
 
+  #assignsの中身を必要とするコンポーネント（こちらが動かない）
+  def input(%{type: "fuga"} = assigns) do
+    IO.inspect("独自のコンポーネント2")
+    ~H"""
+    <div phx-feedback-for={@name}>
+      <.label for={@id}><%= @label %></.label>
+      <textarea
+        id={@id}
+        name={@name}
+        rows={@rows}
+        class={[
+          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
+          "phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400",
+          @errors == [] && "border-zinc-300 focus:border-zinc-400",
+          @errors != [] && "border-rose-400 focus:border-rose-400"
+        ]}
+        {@rest}
+      ><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
+      <.error :for={msg <- @errors}><%= msg %></.error>
+    </div>
+    """
+  end
+
+
 end

--- a/lib/contact_web/components/my_components.ex
+++ b/lib/contact_web/components/my_components.ex
@@ -1,0 +1,68 @@
+defmodule ContactWeb.Mycomponents do
+  use Phoenix.Component
+
+  alias Phoenix.LiveView.JS
+  import ContactWeb.Gettext
+
+  import ContactWeb.CoreComponents
+
+  @doc """
+  Renders an input with label and error messages.
+
+  A `Phoenix.HTML.FormField` may be passed as argument,
+  which is used to retrieve the input name, id, and values.
+  Otherwise all attributes may be passed explicitly.
+
+  ## Types
+
+  This function accepts all HTML input types, considering that:
+
+    * You may also set `type="select"` to render a `<select>` tag
+
+    * `type="checkbox"` is used exclusively to render boolean values
+
+    * For live file uploads, see `Phoenix.Component.live_file_input/1`
+
+  See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
+  for more information.
+
+  ## Examples
+
+      <.input field={@form[:email]} type="email" />
+      <.input name="my-input" errors={["oh no!"]} />
+  """
+  attr :id, :any, default: nil
+  attr :name, :any, default: "pochi"
+  attr :label, :string, default: nil
+  attr :value, :any
+  attr :rows, :integer, default: 2
+
+  attr :type, :string,
+    default: "text",
+    values: ~w(checkbox color date datetime-local email file hidden month number password
+               range radio search select tel text textarea time url week)
+
+  attr :field, Phoenix.HTML.FormField,
+    doc: "a form field struct retrieved from the form, for example: @form[:email]"
+
+  attr :errors, :list, default: []
+  attr :checked, :boolean, doc: "the checked flag for checkbox inputs"
+  attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
+  attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
+  attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
+
+  attr :rest, :global,
+    include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
+                multiple pattern placeholder readonly required rows size step)
+
+  slot :inner_block
+
+  def input(%{type: "fuga"} = assigns) do
+    IO.inspect("fugaのビュー")
+    IO.inspect(assigns)
+    ~H"""
+    <p>Hello, <%= @name %>!</p>
+    """
+  end
+
+end

--- a/lib/contact_web/live/comment_live/form_component.ex
+++ b/lib/contact_web/live/comment_live/form_component.ex
@@ -20,7 +20,8 @@ defmodule ContactWeb.CommentLive.FormComponent do
         phx-submit="save"
       >
         <.input field={@form[:name]} type="text" label="Name" />
-        <ContactWeb.Mycomponents.input field={@form[:message]} type="fuga" label="Message" />
+        <.input field={@form[:message]} type="textarea" label="Message" />
+        <ContactWeb.Mycomponents.input field={@form[:message]} type="hoge"/>
         <:actions>
           <.button phx-disable-with="Saving...">Save Comment</.button>
         </:actions>

--- a/lib/contact_web/live/comment_live/form_component.ex
+++ b/lib/contact_web/live/comment_live/form_component.ex
@@ -22,6 +22,7 @@ defmodule ContactWeb.CommentLive.FormComponent do
         <.input field={@form[:name]} type="text" label="Name" />
         <.input field={@form[:message]} type="textarea" label="Message" />
         <ContactWeb.Mycomponents.input field={@form[:message]} type="hoge"/>
+        <ContactWeb.Mycomponents.input field={@form[:message]} type="fuga" label="Message" />
         <:actions>
           <.button phx-disable-with="Saving...">Save Comment</.button>
         </:actions>

--- a/lib/contact_web/live/comment_live/form_component.ex
+++ b/lib/contact_web/live/comment_live/form_component.ex
@@ -20,7 +20,7 @@ defmodule ContactWeb.CommentLive.FormComponent do
         phx-submit="save"
       >
         <.input field={@form[:name]} type="text" label="Name" />
-        <.input field={@form[:message]} type="textarea" label="Message" />
+        <ContactWeb.Mycomponents.input field={@form[:message]} type="fuga" label="Message" />
         <:actions>
           <.button phx-disable-with="Saving...">Save Comment</.button>
         </:actions>


### PR DESCRIPTION
■目的
この記事（https://qiita.com/Alicesky2127/items/55e97240ba9a97ae2ec8）
で作ったtextareaをレンダリングする関数コンポーネント`input(%{type: "textarea"} = assigns)`について、
core_components.exの外に別モジュールとして作り、そちらを呼び出すように切り替えたい。

なお、新しい関数コンポーネントを置く場所と名前はlib/contact_web/components/my_components.exとする。
└core_components.exと同じ階層に配置。

■影響範囲調査
lib/contact_web/live/comment_live/form_component.ex:23
以上。

■仮説
- my_components.ex
└`use Phoenix.Component`を記述するのでは？
└`core_components.ex`内`input(%{type: "textarea"} = assigns)`を真似して作成するのでは？

- form_component.ex
└呼び出す関数の切り替えが必要では？

■やったこと
- まずassignsの中身を必要としないコンポーネントを作って画面に表示できるか
 └これはできた。
- 次にassignsの中身を必要とするコンポーネントを作って画面に表示できるか
 └以下のエラーメッセージが出て詰まっている。

■結果
**キー :name が見つからないと怒られた。
しかしassignsの中に`name: nil`がある。**
```
 ** (KeyError) key :name not found in: %{__changed__: nil, __given__: %{__changed__: nil, field: %Phoenix.HTML.FormField{id: "comment_message", name: "comment[message]", errors: [], field: :message, form: %Phoenix.HTML.Form{source: #Ecto.Changeset<action: nil, changes: %{}, errors: [name: {"can't be blank", [validation: :required]}, message: {"can't be blank", [validation: :required]}], data: #Contact.Comments.Comment<>, valid?: false>, impl: Phoenix.HTML.FormData.Ecto.Changeset, id: "comment", name: "comment", data: %Contact.Comments.Comment{__meta__: #Ecto.Schema.Metadata<:built, "comments">, id: nil, message: nil, name: nil, inserted_at: nil, updated_at: nil}, hidden: [], params: %{}, errors: [], options: [method: "post"], index: nil, action: nil}, value: nil}, label: "Message", type: "fuga"}, errors: [], field: %Phoenix.HTML.FormField{id: "comment_message", name: "comment[message]", errors: [], field: :message, form: %Phoenix.HTML.Form{source: #Ecto.Changeset<action: nil, changes: %{}, errors: [name: {"can't be blank", [validation: :required]}, message: {"can't be blank", [validation: :required]}], data: #Contact.Comments.Comment<>, valid?: false>, impl: Phoenix.HTML.FormData.Ecto.Changeset, id: "comment", name: "comment", data: %Contact.Comments.Comment{__meta__: #Ecto.Schema.Metadata<:built, "comments">, id: nil, message: nil, name: nil, inserted_at: nil, updated_at: nil}, hidden: [], params: %{}, errors: [], options: [method: "post"], index: nil, action: nil}, value: nil}, id: nil, inner_block: [], label: "Message", multiple: false, prompt: nil, rest: %{}, rows: 2, type: "fuga"}
```



