### PR TITLE
my_components.ex assignsの中身を使わない関数の削除

### DIFF
--- a/lib/contact_web/components/my_components.ex
+++ b/lib/contact_web/components/my_components.ex
@@ -63,14 +63,6 @@ defmodule ContactWeb.Mycomponents do
     |> Mycomponents.input()
   end
 
-  #assignsの中身を必要としないコンポーネント
-  def input(%{type: "hoge"} = assigns) do
-    IO.inspect("独自のコンポーネント1")
-    ~H"""
-    <p>Thank you for your feedback!</p>
-    """
-  end
-
   #assignsの中身を必要とするコンポーネント
   def input(%{type: "fuga"} = assigns) do
     IO.inspect("独自のコンポーネント2")
@@ -91,6 +83,14 @@ defmodule ContactWeb.Mycomponents do
       ><%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
       <CoreComponents.error :for={msg <- @errors}><%= msg %></CoreComponents.error>
     </div>
+    """
+  end
+
+
+  def input(assigns) do
+    IO.inspect("独自のコンポーネント1")
+    ~H"""
+    <p>Thank you for your feedback!</p>
     """
   end
 

--- a/lib/contact_web/components/my_components.ex
+++ b/lib/contact_web/components/my_components.ex
@@ -85,14 +85,4 @@ defmodule ContactWeb.Mycomponents do
     </div>
     """
   end
-
-
-  def input(assigns) do
-    IO.inspect("独自のコンポーネント1")
-    ~H"""
-    <p>Thank you for your feedback!</p>
-    """
-  end
-
-
 end

--- a/lib/contact_web/live/comment_live/form_component.ex
+++ b/lib/contact_web/live/comment_live/form_component.ex
@@ -21,8 +21,8 @@ defmodule ContactWeb.CommentLive.FormComponent do
       >
         <.input field={@form[:name]} type="text" label="Name" />
         <.input field={@form[:message]} type="textarea" label="Message" />
-        <ContactWeb.Mycomponents.input field={@form[:message]} type="hoge"/>
         <ContactWeb.Mycomponents.input field={@form[:message]} type="fuga" label="Message" />
+        <p>Thank you for your feedback!</p>
         <:actions>
           <.button phx-disable-with="Saving...">Save Comment</.button>
         </:actions>


### PR DESCRIPTION
`my_component input/1 type:"hoge"`は
/contact内のフォームに同じメッセージが表示したいという目的で作りました。

しかし、assignsの中身を必要としないコンポーネントは、わざわざコンポーネントのモジュールにアクセスしなくても良いと思うため削除しました。
