### PR TITLE
フォームのtextareaの背景色を変更

### DIFF
--- a/lib/contact_web/components/my_components.ex
+++ b/lib/contact_web/components/my_components.ex
@@ -63,9 +63,7 @@ defmodule ContactWeb.Mycomponents do
     |> Mycomponents.input()
   end
 
-  #assignsの中身を必要とするコンポーネント
-  def input(%{type: "fuga"} = assigns) do
-    IO.inspect("独自のコンポーネント2")
+  def input(%{type: "textarea"} = assigns) do
     ~H"""
     <div phx-feedback-for={@name}>
       <CoreComponents.label for={@id}><%= @label %></CoreComponents.label>

--- a/lib/contact_web/live/comment_live/form_component.ex
+++ b/lib/contact_web/live/comment_live/form_component.ex
@@ -2,6 +2,7 @@ defmodule ContactWeb.CommentLive.FormComponent do
   use ContactWeb, :live_component
 
   alias Contact.Comments
+  alias ContactWeb.Mycomponents
 
   @impl true
   def render(assigns) do
@@ -21,7 +22,7 @@ defmodule ContactWeb.CommentLive.FormComponent do
       >
         <.input field={@form[:name]} type="text" label="Name" />
         <.input field={@form[:message]} type="textarea" label="Message" />
-        <ContactWeb.Mycomponents.input field={@form[:message]} type="textarea" label="Message" />
+        <Mycomponents.input field={@form[:message]} type="textarea" label="Message" />
         <p>Thank you for your feedback!</p>
         <:actions>
           <.button phx-disable-with="Saving...">Save Comment</.button>

--- a/lib/contact_web/live/comment_live/form_component.ex
+++ b/lib/contact_web/live/comment_live/form_component.ex
@@ -21,9 +21,7 @@ defmodule ContactWeb.CommentLive.FormComponent do
         phx-submit="save"
       >
         <.input field={@form[:name]} type="text" label="Name" />
-        <.input field={@form[:message]} type="textarea" label="Message" />
         <Mycomponents.input field={@form[:message]} type="textarea" label="Message" />
-        <p>Thank you for your feedback!</p>
         <:actions>
           <.button phx-disable-with="Saving...">Save Comment</.button>
         </:actions>

--- a/lib/contact_web/live/comment_live/form_component.ex
+++ b/lib/contact_web/live/comment_live/form_component.ex
@@ -21,7 +21,7 @@ defmodule ContactWeb.CommentLive.FormComponent do
       >
         <.input field={@form[:name]} type="text" label="Name" />
         <.input field={@form[:message]} type="textarea" label="Message" />
-        <ContactWeb.Mycomponents.input field={@form[:message]} type="fuga" label="Message" />
+        <ContactWeb.Mycomponents.input field={@form[:message]} type="textarea" label="Message" />
         <p>Thank you for your feedback!</p>
         <:actions>
           <.button phx-disable-with="Saving...">Save Comment</.button>


### PR DESCRIPTION
input/1 type:textareaについて、my_components.ex側のコンポーネントを使用するように変更しました。

結果としてフォームの背景色が"指定なし”から”bg-green-500/50”に変わりました。